### PR TITLE
Version 1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    container: debian/buster:slim
     name: test-swig-build-action
     steps:
     - uses: actions/checkout@v3
     - name: swig build
       uses: ./
       with:
-        version: 4.0.2
+        version: 4.2.0
     - name: swig version
       run: swig -version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ jobs:
     name: test-swig-build-action
     steps:
     - uses: actions/checkout@v3
+    - name: apt
+      run: |
+        apt update
+        apt install -y sudo
     - name: swig build
       uses: ./
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,6 @@ jobs:
     - name: swig build
       uses: ./
       with:
-        version: 4.2.0
+        version: 4.1.1
     - name: swig version
       run: swig -version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
-    container: debian/buster:slim
+    container: debian:buster-slim
     name: test-swig-build-action
     steps:
     - uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
   - name: build-swig
     if: steps.cache-swig.outputs.cache-hit != 'true'
     run: |
-      sudo apt remove '^swig.*' -qq || true
+      sudo apt remove '^swig.*' -y -qq || true
       rm -rf swig_build_dir
       mkdir -p swig_build_dir
       cd swig_build_dir

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
   - name: swig-apt-deps
-    run: sudo apt-get install build-essential libpcre2-dev libpcre3-dev autoconf automake libtool bison git sudo curl -qq -y
+    run: sudo apt-get install build-essential libpcre2-dev libpcre3-dev autoconf automake libtool bison git curl -qq -y
     shell: bash
   - name: cache-swig
     if: startsWith(github.ref, 'refs/tags/v') != true

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
   - name: swig-apt-deps
-    run: sudo apt-get install build-essential libpcre2-dev libpcre3-dev autoconf automake libtool bison git -qq -y
+    run: sudo apt-get install build-essential libpcre2-dev libpcre3-dev autoconf automake libtool bison git sudo curl -qq -y
     shell: bash
   - name: cache-swig
     if: startsWith(github.ref, 'refs/tags/v') != true


### PR DESCRIPTION
Fix bugs:
* Missing apt package curl
* Specify `apt remove -y` to remove system version of swig