### PR TITLE
Update GH cache and checkout versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     container: debian:buster-slim
     name: test-swig-build-action
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: apt
       run: |
         apt update

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
   - name: cache-swig
     if: startsWith(github.ref, 'refs/tags/v') != true
     id: cache-swig
-    uses: actions/cache@v2
+    uses: actions/cache@v4
     with:
       path: swig_build_dir
       key: ${{ runner.os }}-${{ inputs.version }}-swig-${{ inputs.cache-key }}


### PR DESCRIPTION
## Reason for the PR

The action depends on actions/cache version 2, which is scheduled for deprecation. [Announcement](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).


## Fix
- In order to avoid interruptions, this PR updates it to the latest major version (actions/cache@v4).
- It also updates actions/checkout to version 4.

## Notes

This PR addresses: https://github.com/johnwason/swig-build-action/issues/2.
